### PR TITLE
feat: use latest java version

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -84,8 +84,29 @@ def pretty_format_java(argv: typing.Optional[typing.List[str]] = None) -> int:
         args.google_java_formatter_version,
     )
 
+    java_home_cmd = [
+        "/usr/libexec/java_home",
+        "-v",
+        "17"
+    ]
+
+    status, java_home = run_command(*(java_home_cmd))
+
+    if java_home:
+        print(
+            "{}: {}".format(
+                "The following java home will be used",
+                java_home,
+            ),
+        )
+
+    if status != 0:
+        return 1
+
+    java_binary = java_home.strip() + "/bin/java"
+
     cmd_args = [
-        "java",
+        java_binary,
         # export JDK internal classes for Java 16+
         "--add-exports",
         "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",


### PR DESCRIPTION
This is needed so that we use at least java 11, rather than what most people have at $JAVA_HOME which is 1.8.